### PR TITLE
jsdom memory leak workaround

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -58,6 +58,7 @@ module.exports = function scrape(requestOptions, callback, fetchOptions) {
 						$('head').append($(body).find('head').html());
 						$('body').append($(body).find('body').html());
 						callback(null, $);
+						window.close();
 					});
 				} else {
 					callback(new Error('Request to '+requestOptions['uri']+' ended with status code: '+(typeof response !== 'undefined' ? response.statusCode : 'unknown')), null, null);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "repository" : { "type":"git", "url":"https://github.com/mape/node-scraper.git" },
   "dependencies" : {
     "request" : ">=0.10.0",
-    "jsdom" : ">=0.1.20"
+    "jsdom" : ">=0.2.3"
   }
 }


### PR DESCRIPTION
Call windown.close() after we are done with it to release memory.

See discussion here: http://stackoverflow.com/questions/5718391/memory-leak-in-node-js-scraper
