### PR TITLE
Fix failing createWindow() due to change in jsdom API

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -47,13 +47,12 @@ module.exports = function scrape(requestOptions, callback, fetchOptions) {
 			}
 
 			request(requestOptions, function (err, response, body) {
-				body = body.replace(/<(\/?)script/g, '<$1nobreakage');
 				setTimeout(runNextFetch, timeSpacing);
 				if (err) {
 					callback(err, null, null);
 				}
 				if (response && response.statusCode == 200) {
-					var window = jsdom.jsdom().createWindow();
+					var window = jsdom.jsdom(body).defaultView;
 					jsdom.jQueryify(window, __dirname+'/../deps/jquery-1.6.1.min.js', function(win, $) {
 						$('head').append($(body).find('head').html());
 						$('body').append($(body).find('body').html());


### PR DESCRIPTION
This fixes the failure due to change in jsdom API.
Also, it removes the `<script>` tags getting replaced by `<nobreakage>` for better handling by jQuery
